### PR TITLE
Add config to improve visibility in Zen Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ Show a warning message when switching to a file under any of `workspace-root/pat
 "pathsWarning.styles": {
     "activityBar.background": "#f3002b50",
     "statusBar.background": "#f3002b50",
+    "editorGutter.background": "#f3002b50"
 },
 "pathsWarning.include": [
     "vendor",
     "node_modules"
 ],
 "pathsWarning.exclude": [
-    "Code - Insiders",
+    "Code - Insiders"
 ],
 "pathsWarning.showNotification": true,
 "pathsWarning.debug": false


### PR DESCRIPTION
This allow to see the Warning even when the user is using Zen Mode when the notification settings is disabled.

Also remove a useless comma at the same time.